### PR TITLE
removed .env from examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-error.log*
 
 # vscode
 .vscode
+apps/examples/.env

--- a/apps/examples/.env
+++ b/apps/examples/.env
@@ -1,1 +1,0 @@
-OPENAI_API_KEY=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


### PR DESCRIPTION
added .env to gitignore in examples directory, removing exposed openai api key