### PR TITLE
fix(doc): fix variable name used on quick start doc

### DIFF
--- a/apps/docs/docs/quickstart.md
+++ b/apps/docs/docs/quickstart.md
@@ -62,16 +62,16 @@ const text = writePoemPrompt.format({
 Count tokens in text
 
 ```ts
-const tokensUsed = openai.countTokens(text);
+const tokensUsed = provider.countTokens(text);
 ```
 
 Generate text completions!
 
 ```ts
-const response = await openai.generate(text);
+const response = await provider.generate(text);
 
 // Or stream the response!
-await openai.stream(promptText, (chunk: string) => {
+await provider.stream(promptText, (chunk: string) => {
   console.log(chunk);
 });
 ```


### PR DESCRIPTION
Quick start doc did not really make sense because provider is created as
```ts
const provider = new p.OpenAI(apiKey);
```

but then it's used like this 
```ts
const tokensUsed = openai.countTokens(text);
```

So I guess the opposite fix is also possible and rename the provider to openai. Whatever makes the most sense to you that was just a quick PR!