### PR TITLE
Fix result.replaceAll is not a function

### DIFF
--- a/packages/promptable/src/utils/inject-variables.ts
+++ b/packages/promptable/src/utils/inject-variables.ts
@@ -4,7 +4,7 @@ export function injectVariables(
 ): string {
   let result = template;
   for (const key in variables) {
-    result = result.replaceAll(`{{${key}}}`, variables[key]);
+    result = result.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), variables[key]);
   }
   return result;
 }


### PR DESCRIPTION
Using a regex with the global flag is the same thing as using .replaceAll but with better support. 